### PR TITLE
fixed path to normalize.css and added is as explicit dependency

### DIFF
--- a/ng2/example2/angular-cli.json
+++ b/ng2/example2/angular-cli.json
@@ -18,7 +18,7 @@
       "prefix": "app",
       "mobile": false,
       "styles": [
-        "../node_modules/milligram/node_modules/normalize.css/normalize.css",
+        "../node_modules/normalize.css/normalize.css",
         "../node_modules/milligram/dist/milligram.min.css",
         "styles.css"
       ],

--- a/ng2/example2/package.json
+++ b/ng2/example2/package.json
@@ -23,6 +23,7 @@
     "@angular/router": "~3.1.0",
     "core-js": "^2.4.1",
     "milligram": "^1.1.0",
+    "normalize.css": "^5.0.0",
     "rxjs": "5.0.0-beta.12",
     "ts-helpers": "^1.1.1",
     "zone.js": "^0.6.23"


### PR DESCRIPTION
With npm3, nested dependencies are installed different than with npm2 - thats why normalize.css was not found at the specified location after npm install: https://docs.npmjs.com/how-npm-works/npm3

I added normalize.css as an explicit dependency to make sure that it will work with npm2.